### PR TITLE
[修正] 多 import 的 headers 及參數錯字

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -4,7 +4,7 @@ const HTTP_STATUS = {
       message: "OK."
   },
   BAD_REQUEST: {
-      cose: 400,
+      code: 400,
       message: "data not correct or find not todo!"
   },
   NOT_FOUND: {

--- a/deleteTodo.js
+++ b/deleteTodo.js
@@ -1,9 +1,9 @@
-const Handle = require('./handle');
+const handle = require('./handle');
 
 /** 刪除全部 todos */
 const deleteAllTodos = (res, todos) => {
     todos.length = 0;
-    Handle.successHandler(res, todos);
+    handle.successHandler(res, todos);
 }
 
 /** 刪除單筆 todo */
@@ -12,9 +12,9 @@ const deleteSingleTodo = (req, res, todos) => {
     const index = todos.findIndex(item => item.id === id);
     if (index !== -1) {
         todos.splice(index, 1);
-        Handle.successHandler(res, todos, '資料刪除成功');
+        handle.successHandler(res, todos, '資料刪除成功');
     } else {
-        Handle.errorHandle(res, '資料刪除失敗')
+        handle.errorHandle(res, '資料刪除失敗，找不到 id')
     }
 }
 

--- a/deleteTodo.js
+++ b/deleteTodo.js
@@ -3,7 +3,7 @@ const handle = require('./handle');
 /** 刪除全部 todos */
 const deleteAllTodos = (res, todos) => {
     todos.length = 0;
-    handle.successHandler(res, todos);
+    handle.successHandler(res, todos, '資料刪除成功');
 }
 
 /** 刪除單筆 todo */

--- a/handle.js
+++ b/handle.js
@@ -2,7 +2,7 @@ const library = require('./library');
 const HTTP_STATUS = require('./constants')
 
 const errorHandle = (res, message) => {
-    res.writeHead(HTTP_STATUS.BAD_REQUEST.cose, library.headers);
+    res.writeHead(HTTP_STATUS.BAD_REQUEST.code, library.headers);
     res.write(JSON.stringify(
         {
             "status": "false",

--- a/patchTodo.js
+++ b/patchTodo.js
@@ -1,4 +1,3 @@
-const { headers } = require("./library");
 const handle = require('./handle');
 
 const patchTodo = (req, res, todos, body) => {
@@ -10,7 +9,7 @@ const patchTodo = (req, res, todos, body) => {
             todos[index].title = title
             handle.successHandler(res, todos, '資料更新成功');
         } else {
-            handle.errorHandle(res, '欄位未填寫正確,或查無此Id');
+            handle.errorHandle(res, '欄位未填寫正確,或查無此 id');
         }
         res.end()
     } catch (err) {

--- a/postTodo.js
+++ b/postTodo.js
@@ -1,24 +1,5 @@
-const Handle = require('./handle');
+const handle = require('./handle');
 const library = require("./library")
-
-const HTTP_STATUS = {
-    OK: {
-        code: 200,
-        message: "OK."
-    },
-    BAD_REQUEST: {
-        cose: 400,
-        message: "data not correct or find not todo!"
-    },
-    NOT_FOUND: {
-        code: 404,
-        message: "not found."
-    },
-    SERVER_ERROR: {
-        code: 500,
-        message: "Internal Server Error."
-    }
-}
 
 const postTodo = (req, res, todos, body) => {
     try {
@@ -29,12 +10,12 @@ const postTodo = (req, res, todos, body) => {
                 id: library.uuidv4()
             }
             todos.push(todo);
-            Handle.successHandler(res, todos, '資料新增成功');
+            handle.successHandler(res, todos, '資料新增成功');
         } else {
-            Handle.errorHandle(res, '資料新增失敗')
+          handle.errorHandle(res, '資料新增失敗')
         }
     } catch (err) {
-        Handle.errorHandle(res, '發生異常錯誤')
+      handle.errorHandle(res, '發生異常錯誤')
     }
 
 }

--- a/test/test_query.js
+++ b/test/test_query.js
@@ -15,7 +15,7 @@ describe('GET /todos 測試', () => {
             .expect(200)
             .end((err, res) => {
                 assert.notExists(err);
-                assert.hasAllKeys(JSON.parse(res.text), ['status', 'data']);
+                assert.hasAllKeys(JSON.parse(res.text), ['status','message', 'data']);
                 done();
             });
     });
@@ -30,7 +30,7 @@ describe('POST /todos 測試', () => {
             .expect('Content-Type', /json/)
             .end((err, res) => {
                 assert.notExists(err);
-                assert.hasAllKeys(res.body, ['status', 'data']);
+                assert.hasAllKeys(res.body, ['status','message', 'data']);
                 expect(res.body.data).to.be.a('array');
                 expect(res.body.data[0]).to.be.a('object');
                 assert.hasAllKeys(res.body.data[0], ['title', 'id']);
@@ -61,7 +61,7 @@ describe('DELETE /todos 刪除全部 測試', () => {
             .expect(200)
             .end((err, res) => {
                 assert.notExists(err);
-                assert.hasAllKeys(res.body, ['status', 'data']);
+                assert.hasAllKeys(res.body, ['status','message', 'data']);
                 expect(res.body.data).to.be.a('array');
                 assert.equal(res.body.data.length, 0);
                 done();
@@ -94,7 +94,7 @@ describe('DELETE /todos 刪除單筆 測試', () => {
             .expect(200)
             .end((err, res) => {
                 assert.notExists(err);
-                assert.hasAllKeys(res.body, ['status', 'data']);
+                assert.hasAllKeys(res.body, ['status','message','data']);
                 expect(res.body.data).to.be.a('array');
                 expect(res.body.data[0]).to.be.a('object');
                 assert.hasAllKeys(res.body.data[0], ['title', 'id']);
@@ -113,7 +113,7 @@ describe('PATCH /todos 編輯 測試', () => {
             .expect(200)
             .end((err, res) => {
                 assert.notExists(err);
-                assert.hasAllKeys(res.body, ['status', 'data']);
+                assert.hasAllKeys(res.body, ['status','message', 'data']);
                 expect(res.body.data).to.be.a('array');
                 assert.equal(res.body.data.length, 0);
             });
@@ -135,7 +135,7 @@ describe('PATCH /todos 編輯 測試', () => {
             .send(patchObj)
             .end((err, res) => {
                 assert.notExists(err);
-                assert.hasAllKeys(res.body, ['status', 'data']);
+                assert.hasAllKeys(res.body, ['status','message', 'data']);
                 expect(res.body.data).to.be.a('array');
                 expect(res.body.data[0]).to.be.a('object');
                 assert.hasAllKeys(res.body.data[0], ['title', 'id']);


### PR DESCRIPTION
### Objectives 💡
修正以下：

1. `constants.js` 修正錯字：`cose` -> `code`
2. `deleteTodo.js` 統一變數名稱：`Handle` -> `handle`
3. `handle.js` 修正錯字：`cose` -> `code`
4. `patchTodo.js` 修正多引入的 `const { headers } = require("./library");`
5. `postTodo.js` 移除 HTTP_STATUS (已經抽出去 constants.js 的，故不需要)、統一變數名稱 `Handle` -> `handle`
### Notes 📎

