### PR TITLE
[修正] postTodo 改用 mongoose 語法新增 todo

### DIFF
--- a/postTodo.js
+++ b/postTodo.js
@@ -1,23 +1,18 @@
 const handle = require('./handle');
-const library = require("./library")
+const Todo = require('./models/todo');
 
-const postTodo = (req, res, todos, body) => {
+const postTodo = async (res, body) => {
     try {
-        const title = JSON.parse(body).title;
-        if (typeof (title) !== 'undefined') {
-            const todo = {
-                title,
-                id: library.uuidv4()
-            }
-            todos.push(todo);
-            handle.successHandler(res, todos, '資料新增成功');
-        } else {
-          handle.errorHandle(res, '資料新增失敗')
-        }
+        const { title, completed } = JSON.parse(body);
+        const newTodo = await Todo.create({
+            title,
+            completed,
+        });
+        handle.successHandler(res, newTodo, '資料新增成功');
     } catch (err) {
-      handle.errorHandle(res, '發生異常錯誤')
+        const errorField = Object.keys(err.errors).join('、');
+        handle.errorHandle(res, `${errorField} 欄位有誤，請重新確認`);
     }
-
-}
+};
 
 module.exports = postTodo;

--- a/server.js
+++ b/server.js
@@ -27,7 +27,7 @@ const requestListener = async (req, res) => {
     if (req.url == "/todos" && req.method == "GET") {
         getTodo(res, todos)
     } else if (req.url == "/todos" && req.method == "POST") {
-        postTodo(req, res, todos, body)
+        postTodo(res, body)
     } else if (req.url == "/todos" && req.method == "DELETE") {
         deleteAllTodos(res, todos)
     } else if (req.url.startsWith("/todos/") && req.method == "DELETE") {

--- a/test/test_query.js
+++ b/test/test_query.js
@@ -22,23 +22,26 @@ describe('GET /todos 測試', () => {
 });
 
 describe('POST /todos 測試', () => {
-    it('response.body 必須是物件含有 key : status、data, data 內含有 title id, 並且內容吻合', (done) => {
-        const postObj = { "title": "新增資料" }
-        api.post('/todos')
-            .send(postObj)
-            .expect(200)
-            .expect('Content-Type', /json/)
-            .end((err, res) => {
-                assert.notExists(err);
-                assert.hasAllKeys(res.body, ['status','message', 'data']);
-                expect(res.body.data).to.be.a('array');
-                expect(res.body.data[0]).to.be.a('object');
-                assert.hasAllKeys(res.body.data[0], ['title', 'id']);
-                assert.equal(res.body.data[0].title, postObj.title);
-                expect(res.body.data[0].id).to.be.a('string');
-                done();
-            });
-    });
+  it('response.body 必須是物件含有 key : status、message、data, data 內含有 id、title、completed , 並且內容吻合', (done) => {
+      const postObj = {
+          title: '新增資料',
+          completed: true,
+      };
+      api.post('/todos')
+          .send(postObj)
+          .expect(200)
+          .expect('Content-Type', /json/)
+          .end((err, res) => {
+              assert.notExists(err);
+              assert.hasAllKeys(res.body, ['status', 'message', 'data']);
+              expect(res.body.data).to.be.a('object');
+              assert.hasAllKeys(res.body.data, ['_id', 'title', 'completed', 'createdAt', 'updatedAt']);
+              assert.equal(res.body.data.title, postObj.title);
+              assert.equal(res.body.data.completed, postObj.completed);
+              expect(res.body.data._id).to.be.a('string');
+              done();
+          });
+  });
 });
 
 describe('DELETE /todos 刪除全部 測試', () => {


### PR DESCRIPTION
### Objectives 💡
修正以下：
1. postTodo 改寫成 mongoose 的語法新增 todo
2. 修正 server.js postTodo 傳入參數移除 todos
3. 修正 post 單元測試

### Notes 📎
單元測試的部分，由於 `__v` 還沒有移除，所以目前錯出錯。移除 `__v ` 後測試結果為 PASS
